### PR TITLE
DuckDB: Add required packages to pip command

### DIFF
--- a/book/geospatial/duckdb.ipynb
+++ b/book/geospatial/duckdb.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install duckdb pygis"
+    "# %pip install duckdb jupysql duckdb-engine pygis"
    ]
   },
   {


### PR DESCRIPTION
To be able to use the DuckDB SQL magic commands in jupyter, also jupysql and duckdb-engine are required.