### PR TITLE
Add Google Colab and Binder badges to notebooks and markdown files

### DIFF
--- a/book/geospatial/duckdb.ipynb
+++ b/book/geospatial/duckdb.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/duckdb.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/duckdb.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# High-Performance Geospatial Analytics with DuckDB\n",
     "\n",
     "## Introduction\n",
@@ -21,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Library Import and Configuration"
@@ -39,7 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +75,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Understanding DuckDB Connections"
@@ -75,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "### Installing and Loading Extensions"
@@ -100,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## SQL Basics for Spatial Analysis\n",
@@ -149,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,21 +179,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Creating Persistent Tables"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%sql\n",
-    "CREATE OR REPLACE TABLE cities AS SELECT * FROM 'https://opengeos.org/data/duckdb/cities.csv';"
    ]
   },
   {
@@ -195,26 +193,26 @@
    "outputs": [],
    "source": [
     "%%sql\n",
-    "CREATE OR REPLACE TABLE countries AS SELECT * FROM 'https://opengeos.org/data/duckdb/countries.csv';"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "17",
-   "metadata": {},
-   "source": [
-    "### Viewing Your Data"
+    "CREATE OR REPLACE TABLE cities AS SELECT * FROM 'https://opengeos.org/data/duckdb/cities.csv';"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%sql\n",
-    "FROM cities;"
+    "CREATE OR REPLACE TABLE countries AS SELECT * FROM 'https://opengeos.org/data/duckdb/countries.csv';"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "### Viewing Your Data"
    ]
   },
   {
@@ -225,12 +223,23 @@
    "outputs": [],
    "source": [
     "%%sql\n",
+    "FROM cities;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
     "FROM countries;"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Essential SQL Commands\n",
@@ -241,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "#### Choosing Specific Columns"
@@ -260,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "#### Finding Unique Values"
@@ -279,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,21 +298,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "#### Counting and Aggregation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%sql\n",
-    "SELECT COUNT(*) FROM cities;"
    ]
   },
   {
@@ -314,7 +312,7 @@
    "outputs": [],
    "source": [
     "%%sql\n",
-    "SELECT COUNT(DISTINCT country) FROM cities;"
+    "SELECT COUNT(*) FROM cities;"
    ]
   },
   {
@@ -325,7 +323,7 @@
    "outputs": [],
    "source": [
     "%%sql\n",
-    "SELECT MAX(population) FROM cities;"
+    "SELECT COUNT(DISTINCT country) FROM cities;"
    ]
   },
   {
@@ -336,7 +334,7 @@
    "outputs": [],
    "source": [
     "%%sql\n",
-    "SELECT MIN(population) FROM cities;"
+    "SELECT MAX(population) FROM cities;"
    ]
   },
   {
@@ -347,12 +345,23 @@
    "outputs": [],
    "source": [
     "%%sql\n",
+    "SELECT MIN(population) FROM cities;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
     "SELECT AVG(population) FROM cities;"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Filtering and Sorting Data\n",
@@ -363,7 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "#### Sorting Your Results"
@@ -382,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,7 +401,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "#### Grouping and Aggregating Data"
@@ -401,7 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +424,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "## Python API Integration\n",
@@ -426,7 +435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,7 +465,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "### Seamless DataFrame Integration"
@@ -465,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -488,7 +497,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### Result Conversion and Export"
@@ -497,7 +506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +518,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### Persistent Storage"
@@ -518,7 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "## Data Import\n",
@@ -574,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +593,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "### Working with CSV Files"
@@ -593,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -605,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +625,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -638,7 +647,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -648,7 +657,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "source": [
     "### JSON Files"
@@ -657,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,7 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -689,7 +698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "### DataFrames"
@@ -698,7 +707,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -709,7 +718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -718,7 +727,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "source": [
     "### Parquet Files"
@@ -727,7 +736,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -749,7 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,20 +768,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "source": [
     "### Spatial Data Formats"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "71",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.load_extension(\"spatial\")"
    ]
   },
   {
@@ -782,13 +781,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.sql(\"SELECT * FROM ST_Drivers()\")"
+    "con.load_extension(\"spatial\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"SELECT * FROM ST_Drivers()\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -810,7 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -820,7 +829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -830,7 +839,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -843,7 +852,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +861,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "source": [
     "## Data Export\n",
@@ -863,7 +872,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -878,7 +887,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -887,7 +896,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "source": [
     "### Export to DataFrames"
@@ -896,7 +905,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -905,7 +914,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "source": [
     "### Export to Files"
@@ -914,7 +923,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -925,7 +934,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -936,20 +945,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "source": [
     "### Export to JSON"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "88",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(\"COPY cities TO 'cities.json'\")"
    ]
   },
   {
@@ -959,12 +958,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "con.sql(\"COPY cities TO 'cities.json'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "con.sql(\"COPY (SELECT * FROM cities WHERE country='USA') TO 'cities_us.json'\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "source": [
     "### Export to Excel"
@@ -973,7 +982,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -984,7 +993,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "source": [
     "### Export to Parquet"
@@ -993,7 +1002,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1003,7 +1012,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1014,7 +1023,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "source": [
     "### Export Spatial Formats"
@@ -1023,7 +1032,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1034,7 +1043,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1046,7 +1055,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1057,7 +1066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1067,7 +1076,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "source": [
     "## Working with Geometries\n",
@@ -1080,7 +1089,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1092,7 +1101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1105,7 +1114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1114,7 +1123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "source": [
     "### Creating and Understanding Geometries"
@@ -1123,7 +1132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1156,7 +1165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1167,24 +1176,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "source": [
     "### Working with Points"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "109",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(\"\"\"\n",
-    "SELECT ST_AsText(geom)\n",
-    "  FROM samples\n",
-    "  WHERE name = 'Point';\n",
-    "\"\"\")"
    ]
   },
   {
@@ -1195,7 +1190,7 @@
    "outputs": [],
    "source": [
     "con.sql(\"\"\"\n",
-    "SELECT ST_X(geom), ST_Y(geom)\n",
+    "SELECT ST_AsText(geom)\n",
     "  FROM samples\n",
     "  WHERE name = 'Point';\n",
     "\"\"\")"
@@ -1209,7 +1204,9 @@
    "outputs": [],
    "source": [
     "con.sql(\"\"\"\n",
-    "SELECT * FROM nyc_subway_stations\n",
+    "SELECT ST_X(geom), ST_Y(geom)\n",
+    "  FROM samples\n",
+    "  WHERE name = 'Point';\n",
     "\"\"\")"
    ]
   },
@@ -1217,6 +1214,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "112",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "SELECT * FROM nyc_subway_stations\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1229,7 +1238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "source": [
     "### Working with LineStrings"
@@ -1238,7 +1247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1252,7 +1261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1265,7 +1274,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "source": [
     "### Working with Polygons"
@@ -1274,7 +1283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1288,7 +1297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1303,7 +1312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "source": [
     "## Spatial Relationships\n",
@@ -1316,7 +1325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1330,7 +1339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "source": [
     "### Testing Spatial Equality"
@@ -1339,7 +1348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1353,7 +1362,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "123",
+   "id": "124",
    "metadata": {},
    "source": [
     "### Point-in-Polygon Analysis"
@@ -1362,7 +1371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1372,7 +1381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "125",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1386,7 +1395,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "126",
+   "id": "127",
    "metadata": {},
    "source": [
     "### Proximity Analysis with Distance"
@@ -1395,7 +1404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "127",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1409,7 +1418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "128",
+   "id": "129",
    "metadata": {},
    "source": [
     "## Spatial Joins\n",
@@ -1422,7 +1431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1432,7 +1441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1441,7 +1450,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "131",
+   "id": "132",
    "metadata": {},
    "source": [
     "### Your First Spatial Join"
@@ -1450,7 +1459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "132",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1469,7 +1478,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "133",
+   "id": "134",
    "metadata": {},
    "source": [
     "### Advanced Spatial Analysis"
@@ -1478,7 +1487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "134",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1490,7 +1499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "135",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1509,7 +1518,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "136",
+   "id": "137",
    "metadata": {},
    "source": [
     "### Distance-Based Analysis"
@@ -1518,7 +1527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "137",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1535,7 +1544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "138",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1549,7 +1558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "139",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1568,7 +1577,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "140",
+   "id": "141",
    "metadata": {},
    "source": [
     "### Advanced Multi-Table Joins"
@@ -1577,7 +1586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "141",
+   "id": "142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1595,7 +1604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "142",
+   "id": "143",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1618,7 +1627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "143",
+   "id": "144",
    "metadata": {},
    "source": [
     "## Large-Scale Data Analysis\n",
@@ -1629,7 +1638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "144",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1642,7 +1651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "145",
+   "id": "146",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1655,7 +1664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "146",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1665,7 +1674,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "147",
+   "id": "148",
    "metadata": {},
    "source": [
     "### Scaling Up: Nationwide Wetland Analysis\n",
@@ -1676,7 +1685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "148",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1688,7 +1697,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "149",
+   "id": "150",
    "metadata": {},
    "source": [
     "#### Count Wetlands by State"
@@ -1697,7 +1706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "150",
+   "id": "151",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1714,7 +1723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "151",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1731,7 +1740,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "152",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1742,7 +1751,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "153",
+   "id": "154",
    "metadata": {},
    "source": [
     "### Mapping Wetland Counts by State"
@@ -1751,7 +1760,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "154",
+   "id": "155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1766,7 +1775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "155",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1778,7 +1787,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "156",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1797,7 +1806,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "157",
+   "id": "158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1814,7 +1823,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "158",
+   "id": "159",
    "metadata": {},
    "source": [
     "### Wetland Distribution Charts\n",
@@ -1825,7 +1834,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "159",
+   "id": "160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1836,7 +1845,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "160",
+   "id": "161",
    "metadata": {},
    "source": [
     "#### Bar Chart of Wetlands by State"
@@ -1845,7 +1854,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "161",
+   "id": "162",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1854,7 +1863,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "162",
+   "id": "163",
    "metadata": {},
    "source": [
     "### Wetland Area Analysis\n",
@@ -1865,7 +1874,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "163",
+   "id": "164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1877,7 +1886,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "164",
+   "id": "165",
    "metadata": {},
    "source": [
     "#### Wetland Area by State"
@@ -1886,7 +1895,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "165",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1901,7 +1910,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "166",
+   "id": "167",
    "metadata": {},
    "source": [
     "#### Pie Chart of Wetland Area by State"
@@ -1910,7 +1919,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "167",
+   "id": "168",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1921,7 +1930,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "168",
+   "id": "169",
    "metadata": {},
    "source": [
     "#### Bar Chart of Wetland Area by State"
@@ -1930,7 +1939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "169",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1939,7 +1948,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "170",
+   "id": "171",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -1958,14 +1967,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "171",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "172",
+   "id": "173",
    "metadata": {},
    "source": [
     "### Exercise 2: Column Filtering"
@@ -1974,14 +1983,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "173",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "174",
+   "id": "175",
    "metadata": {},
    "source": [
     "### Exercise 3: Row Filtering"
@@ -1990,14 +1999,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "175",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "176",
+   "id": "177",
    "metadata": {},
    "source": [
     "### Exercise 4: Sorting Results"
@@ -2006,14 +2015,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "177",
+   "id": "178",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "178",
+   "id": "179",
    "metadata": {},
    "source": [
     "### Exercise 5: Unique Values"
@@ -2022,14 +2031,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "179",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "180",
+   "id": "181",
    "metadata": {},
    "source": [
     "### Exercise 6: Counting Rows"
@@ -2038,14 +2047,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "181",
+   "id": "182",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "182",
+   "id": "183",
    "metadata": {},
    "source": [
     "### Exercise 7: Aggregating Data"
@@ -2054,14 +2063,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "183",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "184",
+   "id": "185",
    "metadata": {},
    "source": [
     "### Exercise 8: Joining Tables"
@@ -2070,14 +2079,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "185",
+   "id": "186",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "186",
+   "id": "187",
    "metadata": {},
    "source": [
     "### Exercise 9: String Manipulation"
@@ -2086,14 +2095,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "187",
+   "id": "188",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "188",
+   "id": "189",
    "metadata": {},
    "source": [
     "### Exercise 10: Filtering with Multiple Conditions"
@@ -2102,14 +2111,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "189",
+   "id": "190",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "190",
+   "id": "191",
    "metadata": {},
    "source": [
     "### Exercise 11: Basic Setup and Data Loading"
@@ -2118,14 +2127,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "191",
+   "id": "192",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "192",
+   "id": "193",
    "metadata": {},
    "source": [
     "### Exercise 12: Spatial Relationships Analysis"
@@ -2134,26 +2143,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "193",
+   "id": "194",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "194",
+   "id": "195",
    "metadata": {},
    "source": [
     "### Exercise 13: Advanced Spatial Joins"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "195",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -2196,20 +2197,20 @@
    "source": []
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "201",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "202",
    "metadata": {},
    "source": [
     "### Exercise 14: Data Import and Export"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "202",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -2228,20 +2229,20 @@
    "source": []
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "205",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "206",
    "metadata": {},
    "source": [
     "### Exercise 15: Large-Scale Analysis"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "206",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -2263,6 +2264,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "209",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "210",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/duckdb.md
+++ b/book/geospatial/duckdb.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/duckdb.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/duckdb.ipynb)
+
 # High-Performance Geospatial Analytics with DuckDB
 
 ## Introduction

--- a/book/geospatial/gdal.ipynb
+++ b/book/geospatial/gdal.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/gdal.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/gdal.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Geospatial Data Processing with GDAL and OGR\n",
     "\n",
     "## Introduction\n",
@@ -25,7 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Understanding Your Data\n",
@@ -55,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,20 +73,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Examining Vector Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ogrinfo buildings.geojson"
    ]
   },
   {
@@ -87,12 +86,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "ogrinfo buildings.geojson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ogrinfo buildings.geojson -al -so"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Coordinate Transformation\n",
@@ -103,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "### Reprojecting Vector Data"
@@ -121,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Format Conversion\n",
@@ -141,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,20 +159,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Converting Vector Formats"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ogr2ogr buildings.gpkg buildings.geojson"
    ]
   },
   {
@@ -173,12 +172,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "ogr2ogr buildings.gpkg buildings.geojson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ogr2ogr las_vegas_bbox.fgb las_vegas_bbox.geojson"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Clipping and Masking\n",
@@ -189,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,20 +207,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Clipping Vector Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ogr2ogr -clipsrc las_vegas_bbox.geojson las_vegas_roads_clipped.geojson las_vegas_roads.geojson"
    ]
   },
   {
@@ -221,7 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ogrinfo las_vegas_bbox_4326.geojson -al -so"
+    "ogr2ogr -clipsrc las_vegas_bbox.geojson las_vegas_roads_clipped.geojson las_vegas_roads.geojson"
    ]
   },
   {
@@ -231,12 +230,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "ogrinfo las_vegas_bbox_4326.geojson -al -so"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ogr2ogr -clipsrc -115.387634 35.943333 -114.883495 36.359161 las_vegas_roads_clipped.geojson las_vegas_roads.geojson"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "## Raster Analysis and Calculations\n",
@@ -247,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Performing Band Mathematics"
@@ -267,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "## Converting Between Raster and Vector\n",
@@ -339,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,20 +357,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Rasterization"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "34",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdal_rasterize -a uid -tr 0.6 0.6 -l buildings buildings_3857.gpkg buildings.tif"
    ]
   },
   {
@@ -371,12 +370,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "gdal_rasterize -a uid -tr 0.6 0.6 -l buildings buildings_3857.gpkg buildings.tif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "gdal_rasterize -burn 1 -tr 0.6 0.6 -l buildings buildings_3857.gpkg buildings2.tif"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "## Geometry Processing\n",
@@ -387,7 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,20 +405,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "### Dissolving Features by Attributes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "39",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ogrinfo -al -so us_states.geojson"
    ]
   },
   {
@@ -419,12 +418,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "ogrinfo -al -so us_states.geojson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ogr2ogr -dialect sqlite -sql \"SELECT ST_Union(geometry), country FROM us_states GROUP BY country\" us_states_dissolved.gpkg us_states.geojson"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "### Exploding Multi-part Geometries"
@@ -433,7 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## Managing Fields and Layers\n",
@@ -453,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +471,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### Renaming Layers"
@@ -471,7 +480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,7 +489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### Adding New Fields"
@@ -489,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -498,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "## Tiling and Data Management\n",
@@ -509,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,20 +537,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "source": [
     "### Merging Raster Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "53",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdal_merge.py -o landsat_merged.tif -of GTiff tiles/*.tif"
    ]
   },
   {
@@ -551,12 +550,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "gdal_merge.py -o landsat_merged.tif -of GTiff tiles/*.tif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "gdalwarp -of GTiff tiles/*.tif landsat_merged2.tif"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "### Working with Multiple Vector Files"
@@ -565,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,7 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -607,7 +616,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "source": [
     "## Advanced Raster Processing\n",
@@ -618,7 +627,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,20 +636,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "### Creating Band Composites"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "63",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdal_merge.py -separate -o composite.tif nir.tif red.tif green.tif"
    ]
   },
   {
@@ -650,26 +649,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "gdal_merge.py -separate -o composite.tif nir.tif red.tif green.tif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "gdalbuildvrt -separate stack.vrt nir.tif red.tif green.tif\n",
     "gdal_translate stack.vrt composite.tif -co COMPRESS=DEFLATE"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "### Handling Missing Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "66",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdal_fillnodata.py -md 5 -of GTiff dem.tif filled_dem.tif"
    ]
   },
   {
@@ -679,12 +678,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "gdal_fillnodata.py -md 5 -of GTiff dem.tif filled_dem.tif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "gdal_translate -a_nodata 0 dem.tif dem_nodata.tif"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "source": [
     "### Cloud Optimized GeoTIFF"
@@ -693,7 +702,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -702,7 +711,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "source": [
     "## Terrain Analysis\n",
@@ -713,7 +722,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -737,7 +746,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "source": [
     "### Computing Aspect"
@@ -746,7 +755,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -757,20 +766,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "source": [
     "### Creating Hillshade Visualizations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "76",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdaldem hillshade dem.tif hillshade.tif"
    ]
   },
   {
@@ -780,12 +779,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "gdaldem hillshade dem.tif hillshade.tif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "gdaldem hillshade dem.tif multidirectional_hillshade.tif -multidirectional"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "source": [
     "### Creating Color Relief Maps"
@@ -794,7 +803,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -813,7 +822,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -822,7 +831,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "source": [
     "### Combining Hillshade and Color Relief"
@@ -831,7 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -846,7 +855,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -861,7 +870,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -873,7 +882,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +891,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "source": [
     "### Generating Contour Lines"
@@ -891,7 +900,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -900,7 +909,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -915,14 +924,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "source": [
     "### Exercise 2: Coordinate Transformation Practice"
@@ -931,14 +940,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "source": [
     "### Exercise 3: Format Conversion and Optimization"
@@ -947,14 +956,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "source": [
     "### Exercise 4: Spatial Clipping and Analysis"
@@ -963,14 +972,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "source": [
     "### Exercise 5: Raster Band Mathematics"
@@ -979,14 +988,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "source": [
     "### Exercise 6: Terrain Analysis Workflow"
@@ -995,14 +1004,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "source": [
     "### Exercise 7: Raster-Vector Conversion"
@@ -1011,14 +1020,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "source": [
     "### Exercise 8: Geometry Processing and Data Management"
@@ -1027,7 +1036,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/gdal.md
+++ b/book/geospatial/gdal.md
@@ -10,6 +10,10 @@ kernelspec:
   language: bash
   name: bash
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/gdal.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/gdal.ipynb)
+
 # Geospatial Data Processing with GDAL and OGR
 
 ## Introduction

--- a/book/geospatial/geemap.ipynb
+++ b/book/geospatial/geemap.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/geemap.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/geemap.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Cloud Computing with Earth Engine and Geemap\n",
     "\n",
     "## Introduction\n",
@@ -23,7 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +41,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Import Libraries"
@@ -41,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,20 +60,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Authenticate and Initialize Earth Engine"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ee.Authenticate()"
    ]
   },
   {
@@ -74,25 +73,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ee.Initialize(project=\"your-ee-project\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7",
-   "metadata": {},
-   "source": [
-    "### Creating Interactive Maps"
+    "ee.Authenticate()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = geemap.Map()"
+    "ee.Initialize(project=\"your-ee-project\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "### Creating Interactive Maps"
    ]
   },
   {
@@ -102,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m"
+    "m = geemap.Map()"
    ]
   },
   {
@@ -112,7 +111,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = geemap.Map(center=[40, -100], zoom=4, height=\"600px\")\n",
     "m"
    ]
   },
@@ -123,13 +121,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "m = geemap.Map(center=[40, -100], zoom=4, height=\"600px\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "m = geemap.Map(data_ctrl=False, toolbar_ctrl=False, draw_ctrl=False)\n",
     "m"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Adding Basemaps"
@@ -138,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,20 +157,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "#### Adding Multiple Basemaps"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m.add_basemap(\"Esri.WorldTopoMap\")"
    ]
   },
   {
@@ -171,12 +170,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "m.add_basemap(\"Esri.WorldTopoMap\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "m.add_basemap(\"OpenTopoMap\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Google Basemaps"
@@ -185,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Introduction to Interactive Maps and Tools\n",
@@ -218,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Layer Manager"
@@ -238,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Inspector Tool"
@@ -267,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +302,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Layer Editor\n",
@@ -304,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "#### Multi-Band image"
@@ -331,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +357,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "#### Feature Collection"
@@ -357,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Draw Control"
@@ -379,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +419,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "## The Earth Engine Data Catalog\n",
@@ -423,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Using the Datasets Module in Geemap"
@@ -442,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +486,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "## Earth Engine Data Types\n",
@@ -492,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -502,7 +511,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "#### Visualizing Earth Engine Images"
@@ -511,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +537,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### ImageCollection\n",
@@ -539,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +557,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "#### Filtering Image Collections"
@@ -557,7 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +603,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -614,7 +623,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "source": [
     "#### Visualizing Image Collections"
@@ -623,7 +632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -643,7 +652,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "## Earth Engine Vector Data\n",
@@ -654,7 +663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +676,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "### Filtering Feature Collections"
@@ -676,7 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -702,7 +711,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -712,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -727,7 +736,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +752,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,7 +772,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "### Visualizing Feature Collections"
@@ -772,7 +781,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -785,7 +794,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -823,7 +832,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "## More Tools for Visualizing Earth Engine Data\n",
@@ -834,7 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -864,7 +873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -874,7 +883,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -883,7 +892,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "source": [
     "### Legends\n",
@@ -894,7 +903,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,7 +916,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -921,7 +930,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -940,7 +949,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "source": [
     "#### Custom Legends"
@@ -949,7 +958,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -989,7 +998,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "source": [
     "### Color Bars"
@@ -998,7 +1007,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1019,7 +1028,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1034,7 +1043,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "### Split-panel Maps"
@@ -1043,7 +1052,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1055,7 +1064,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1073,7 +1082,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "source": [
     "### Linked Maps"
@@ -1082,7 +1091,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1123,7 +1132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "source": [
     "### Timeseries Inspector"
@@ -1132,7 +1141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1164,7 +1173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "source": [
     "### Time Slider"
@@ -1173,7 +1182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1197,7 +1206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1224,7 +1233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1246,7 +1255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "source": [
     "## Vector Data Processing\n",
@@ -1257,7 +1266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1270,7 +1279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "source": [
     "### From Shapefile"
@@ -1279,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1290,7 +1299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1303,7 +1312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "source": [
     "### From GeoDataFrame"
@@ -1312,7 +1321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1327,7 +1336,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "source": [
     "### To GeoJSON"
@@ -1336,7 +1345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1351,7 +1360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1360,7 +1369,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "source": [
     "### To Shapefile"
@@ -1369,7 +1378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1378,7 +1387,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "source": [
     "### To GeoDataFrame"
@@ -1387,7 +1396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1398,7 +1407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1407,7 +1416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "source": [
     "### To DataFrame"
@@ -1416,7 +1425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1426,7 +1435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "source": [
     "### To CSV"
@@ -1435,7 +1444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "110",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1444,7 +1453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "111",
+   "id": "112",
    "metadata": {},
    "source": [
     "## Raster Data Processing\n",
@@ -1457,7 +1466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "112",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1484,7 +1493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1496,7 +1505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1507,7 +1516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1517,7 +1526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1528,7 +1537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1538,7 +1547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1548,7 +1557,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "source": [
     "#### Extracting Pixel Values Along a Transect"
@@ -1557,7 +1566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1577,7 +1586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1593,7 +1602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1607,7 +1616,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "123",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1625,7 +1634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1634,7 +1643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "125",
+   "id": "126",
    "metadata": {},
    "source": [
     "### Zonal Statistics\n",
@@ -1645,7 +1654,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "126",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1675,7 +1684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "127",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1688,7 +1697,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "128",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1705,7 +1714,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "129",
+   "id": "130",
    "metadata": {},
    "source": [
     "#### Zonal Statistics by Group"
@@ -1714,7 +1723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1738,7 +1747,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "131",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1758,7 +1767,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "132",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1777,7 +1786,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "133",
+   "id": "134",
    "metadata": {},
    "source": [
     "#### Zonal Statistics with Two Images"
@@ -1786,7 +1795,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "134",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1803,7 +1812,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "135",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1814,7 +1823,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "136",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1824,7 +1833,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "137",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1833,7 +1842,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "138",
+   "id": "139",
    "metadata": {},
    "source": [
     "### Map Algebra"
@@ -1842,7 +1851,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "139",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1867,7 +1876,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "140",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1895,7 +1904,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "141",
+   "id": "142",
    "metadata": {},
    "source": [
     "## Exporting Earth Engine Data\n",
@@ -1906,7 +1915,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "142",
+   "id": "143",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1926,7 +1935,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "143",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1939,7 +1948,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "144",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1949,7 +1958,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "145",
+   "id": "146",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1960,7 +1969,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "146",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1971,7 +1980,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "147",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1987,7 +1996,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "148",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1999,7 +2008,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "149",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2008,7 +2017,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "150",
+   "id": "151",
    "metadata": {},
    "source": [
     "### Exporting Image Collections"
@@ -2017,7 +2026,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "151",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2034,7 +2043,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "152",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2044,7 +2053,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "153",
+   "id": "154",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2053,7 +2062,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "154",
+   "id": "155",
    "metadata": {},
    "source": [
     "### Exporting Feature Collections"
@@ -2062,7 +2071,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "155",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2077,7 +2086,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "156",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2092,7 +2101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "157",
+   "id": "158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2103,7 +2112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "158",
+   "id": "159",
    "metadata": {},
    "source": [
     "## Creating Timelapse Animations\n",
@@ -2114,7 +2123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "159",
+   "id": "160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2128,7 +2137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "160",
+   "id": "161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2148,7 +2157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "161",
+   "id": "162",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2162,7 +2171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "162",
+   "id": "163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2182,7 +2191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "163",
+   "id": "164",
    "metadata": {},
    "source": [
     "### Sentinel-2 Timelapse"
@@ -2191,7 +2200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "164",
+   "id": "165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2202,7 +2211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "165",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2216,7 +2225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "166",
+   "id": "167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2237,7 +2246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "167",
+   "id": "168",
    "metadata": {},
    "source": [
     "### MODIS Timelapse"
@@ -2246,7 +2255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "168",
+   "id": "169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2257,7 +2266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "169",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2271,7 +2280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "170",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2292,7 +2301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "171",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2303,7 +2312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "172",
+   "id": "173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2317,7 +2326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "173",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2337,7 +2346,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "174",
+   "id": "175",
    "metadata": {},
    "source": [
     "### GOES Timelapse"
@@ -2346,7 +2355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "175",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2360,7 +2369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "176",
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2373,7 +2382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "177",
+   "id": "178",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2387,7 +2396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "178",
+   "id": "179",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2400,7 +2409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "179",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2414,7 +2423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "180",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2426,7 +2435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "181",
+   "id": "182",
    "metadata": {},
    "source": [
     "## Charting Earth Engine Data\n",
@@ -2439,7 +2448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "182",
+   "id": "183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2449,7 +2458,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "183",
+   "id": "184",
    "metadata": {},
    "source": [
     "#### feature_by_feature"
@@ -2458,7 +2467,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "184",
+   "id": "185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2470,7 +2479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "185",
+   "id": "186",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2512,7 +2521,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "186",
+   "id": "187",
    "metadata": {},
    "source": [
     "#### feature.by_property"
@@ -2521,7 +2530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "187",
+   "id": "188",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2533,7 +2542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "188",
+   "id": "189",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2558,7 +2567,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "189",
+   "id": "190",
    "metadata": {},
    "source": [
     "#### feature_groups"
@@ -2567,7 +2576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "190",
+   "id": "191",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2597,7 +2606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "191",
+   "id": "192",
    "metadata": {},
    "source": [
     "#### feature_histogram"
@@ -2606,7 +2615,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "192",
+   "id": "193",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2619,7 +2628,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "193",
+   "id": "194",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2639,7 +2648,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "194",
+   "id": "195",
    "metadata": {},
    "source": [
     "### Charting Images\n",
@@ -2650,7 +2659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "195",
+   "id": "196",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2676,7 +2685,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "196",
+   "id": "197",
    "metadata": {},
    "source": [
     "#### image_regions"
@@ -2685,7 +2694,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "197",
+   "id": "198",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2716,7 +2725,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "198",
+   "id": "199",
    "metadata": {},
    "source": [
     "#### image_by_class"
@@ -2725,7 +2734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "199",
+   "id": "200",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2757,7 +2766,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "200",
+   "id": "201",
    "metadata": {},
    "source": [
     "#### image_histogram"
@@ -2766,7 +2775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "201",
+   "id": "202",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2794,7 +2803,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "202",
+   "id": "203",
    "metadata": {},
    "source": [
     "### Charting Image Collections\n",
@@ -2805,7 +2814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "203",
+   "id": "204",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2846,7 +2855,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "204",
+   "id": "205",
    "metadata": {},
    "source": [
     "#### image_series_by_region"
@@ -2855,7 +2864,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "205",
+   "id": "206",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2897,7 +2906,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "206",
+   "id": "207",
    "metadata": {},
    "source": [
     "#### image_doy_series"
@@ -2906,7 +2915,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "207",
+   "id": "208",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2943,7 +2952,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "208",
+   "id": "209",
    "metadata": {},
    "source": [
     "#### image_doy_series_by_year"
@@ -2952,7 +2961,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "209",
+   "id": "210",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2995,7 +3004,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "210",
+   "id": "211",
    "metadata": {},
    "source": [
     "#### image_doy_series_by_region"
@@ -3004,7 +3013,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "211",
+   "id": "212",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3046,7 +3055,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "212",
+   "id": "213",
    "metadata": {},
    "source": [
     "### Charting Array and List\n",
@@ -3057,7 +3066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "213",
+   "id": "214",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3107,7 +3116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "214",
+   "id": "215",
    "metadata": {},
    "source": [
     "#### Transect Line Plot"
@@ -3116,7 +3125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "215",
+   "id": "216",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3164,7 +3173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "216",
+   "id": "217",
    "metadata": {},
    "source": [
     "#### Metadata Scatter Plot"
@@ -3173,7 +3182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "217",
+   "id": "218",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3209,7 +3218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "218",
+   "id": "219",
    "metadata": {},
    "source": [
     "#### Mapped Function Scatter & Line Plot"
@@ -3218,7 +3227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "219",
+   "id": "220",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3249,7 +3258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "220",
+   "id": "221",
    "metadata": {},
    "source": [
     "### Charting Data Table\n",
@@ -3260,7 +3269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "221",
+   "id": "222",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3278,7 +3287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "222",
+   "id": "223",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3297,7 +3306,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "223",
+   "id": "224",
    "metadata": {},
    "source": [
     "#### Computed DataTable chart"
@@ -3306,7 +3315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "224",
+   "id": "225",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3363,7 +3372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "225",
+   "id": "226",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3384,7 +3393,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "226",
+   "id": "227",
    "metadata": {},
    "source": [
     "#### Interval chart"
@@ -3393,7 +3402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "227",
+   "id": "228",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3489,7 +3498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "228",
+   "id": "229",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3515,7 +3524,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "229",
+   "id": "230",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -3528,14 +3537,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "230",
+   "id": "231",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "231",
+   "id": "232",
    "metadata": {},
    "source": [
     "### Exercise 2: Cloud-Free Composite with Sentinel-2 or Landsat"
@@ -3544,14 +3553,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "232",
+   "id": "233",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "233",
+   "id": "234",
    "metadata": {},
    "source": [
     "### Exercise 3: Visualizing NAIP Imagery"
@@ -3560,14 +3569,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "234",
+   "id": "235",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "235",
+   "id": "236",
    "metadata": {},
    "source": [
     "### Exercise 4: Visualizing Watershed Boundaries"
@@ -3576,14 +3585,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "236",
+   "id": "237",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "237",
+   "id": "238",
    "metadata": {},
    "source": [
     "### Exercise 5: Visualizing Land Cover Change"
@@ -3592,14 +3601,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "238",
+   "id": "239",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "239",
+   "id": "240",
    "metadata": {},
    "source": [
     "### Exercise 6: Creating a Landsat Timelapse Animation"
@@ -3608,7 +3617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "240",
+   "id": "241",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/geemap.md
+++ b/book/geospatial/geemap.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/geemap.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/geemap.ipynb)
+
 # Cloud Computing with Earth Engine and Geemap
 
 ## Introduction

--- a/book/geospatial/geopandas.ipynb
+++ b/book/geospatial/geopandas.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/geopandas.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/geopandas.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Vector Data Analysis with GeoPandas\n",
     "\n",
     "## Introduction\n",
@@ -23,7 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Creating GeoDataFrames\n",
@@ -55,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Reading and Writing Geospatial Data\n",
@@ -89,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "### Writing Geospatial Data"
@@ -109,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Projections and Coordinate Reference Systems (CRS)\n",
@@ -149,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Reprojecting to Different Coordinate Systems"
@@ -167,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Spatial Measurements and Analysis\n",
@@ -190,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Calculating Areas"
@@ -212,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +237,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Extracting Geometric Features"
@@ -237,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Distance Calculations"
@@ -262,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Statistical Analysis of Spatial Data"
@@ -289,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Visualizing Geospatial Data\n",
@@ -316,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Thematic Mapping"
@@ -337,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Multi-Layer Visualization"
@@ -370,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +419,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Interactive Visualization"
@@ -419,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "## Advanced Geometric Operations\n",
@@ -447,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "### Convex Hull Analysis"
@@ -505,7 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,7 +565,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "## Spatial Relationships and Queries\n",
@@ -567,7 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +593,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Containment and Spatial Validation"
@@ -593,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +620,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "## Best Practices and Performance Considerations\n",
@@ -632,14 +641,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Exercise 2: Combining NumPy, Pandas, and GeoPandas"
@@ -648,7 +657,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/geopandas.md
+++ b/book/geospatial/geopandas.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/geopandas.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/geopandas.ipynb)
+
 # Vector Data Analysis with GeoPandas
 
 ## Introduction

--- a/book/geospatial/get-started.ipynb
+++ b/book/geospatial/get-started.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/get-started.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/get-started.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Introduction to Geospatial Python\n",
     "\n",
     "## Introduction\n",
@@ -84,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Create Your First Interactive Map"
@@ -111,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Learning Path and Chapter Overview\n",

--- a/book/geospatial/get-started.md
+++ b/book/geospatial/get-started.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/get-started.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/get-started.ipynb)
+
 # Introduction to Geospatial Python
 
 ## Introduction

--- a/book/geospatial/hypercoast.ipynb
+++ b/book/geospatial/hypercoast.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/hypercoast.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/hypercoast.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Hyperspectral Data Visualization with HyperCoast\n",
     "\n",
     "## Introduction\n",
@@ -17,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Finding Hyperspectral Data\n",
@@ -57,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Interactive Search"
@@ -100,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Downloading Hyperspectral Data"
@@ -141,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Reading Hyperspectral Data"
@@ -161,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Visualizing Hyperspectral Data"
@@ -180,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Creating Image Cubes"
@@ -202,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Interactive Slicing"
@@ -239,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Interactive Thresholding"
@@ -278,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",

--- a/book/geospatial/hypercoast.md
+++ b/book/geospatial/hypercoast.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/hypercoast.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/hypercoast.ipynb)
+
 # Hyperspectral Data Visualization with HyperCoast
 
 ## Introduction

--- a/book/geospatial/leafmap.ipynb
+++ b/book/geospatial/leafmap.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/leafmap.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/leafmap.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Interactive Visualization with Leafmap\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Understanding Leafmap's Backend Architecture"
@@ -57,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Creating Interactive Maps\n",
@@ -78,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Customizing Map Properties\n",
@@ -99,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "### Managing Map Controls\n",
@@ -123,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "#### Adding Search Functionality"
@@ -152,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Working with Map Layers\n",
@@ -178,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "#### Layer Management Operations"
@@ -199,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "#### Clearing Map Content"
@@ -222,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +250,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Changing Basemaps\n",
@@ -254,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +274,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Interactive Basemap Selection"
@@ -274,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +294,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Adding Custom XYZ Tile Layers"
@@ -294,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Adding Web Map Service (WMS) Layers"
@@ -318,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,7 +346,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Adding Legends for Data Context"
@@ -346,7 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Adding Colorbars for Continuous Data"
@@ -376,7 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +414,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Visualizing Vector Data\n",
@@ -427,7 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "#### Adding Multiple Markers Efficiently"
@@ -448,7 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "#### Managing Large Point Datasets with Clustering"
@@ -474,7 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +495,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "#### Advanced Marker Customization"
@@ -495,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -517,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "### Visualizing Polylines"
@@ -526,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +547,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "#### Customizing Polyline Styles"
@@ -547,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "### Visualizing Polygons"
@@ -570,7 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,7 +591,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Visualizing GeoPandas GeoDataFrames"
@@ -591,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -603,7 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -613,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "source": [
     "## Creating Choropleth Maps"
@@ -635,7 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +676,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "## Visualizing GeoParquet Data\n",
@@ -678,7 +687,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -690,7 +699,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,7 +709,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -711,7 +720,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "source": [
     "### Visualizing Polygon Data"
@@ -720,7 +729,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +751,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -754,7 +763,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "## Visualizing PMTiles\n",
@@ -765,7 +774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -777,7 +786,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "### Visualizing PMTiles Data"
@@ -786,7 +795,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -828,7 +837,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "### Visualizing Open Buildings Data with PMTiles"
@@ -837,7 +846,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -850,7 +859,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -886,7 +895,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "source": [
     "### Visualizing Overture Maps Data"
@@ -895,7 +904,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -906,7 +915,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -917,7 +926,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -949,7 +958,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -961,7 +970,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "source": [
     "## Visualizing Raster Data\n",
@@ -974,7 +983,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -987,7 +996,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -997,7 +1006,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1007,7 +1016,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1017,7 +1026,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "#### Adding Multiple COGs"
@@ -1026,7 +1035,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1037,7 +1046,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "source": [
     "#### Creating a Split Map for Comparison"
@@ -1046,7 +1055,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1060,7 +1069,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1080,7 +1089,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "source": [
     "#### Using a Custom Colormap"
@@ -1089,7 +1098,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1126,7 +1135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "source": [
     "### Visualizing Local Raster Datasets\n",
@@ -1137,7 +1146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1149,7 +1158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1161,7 +1170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1171,7 +1180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1180,7 +1189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "source": [
     "#### Visualizing a Multi-Band Raster"
@@ -1189,7 +1198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1199,7 +1208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1211,7 +1220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1222,7 +1231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "source": [
     "#### Inspecting Pixel Values"
@@ -1231,7 +1240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1243,7 +1252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "source": [
     "### Visualizing SpatioTemporal Asset Catalog (STAC) Data\n",
@@ -1254,7 +1263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1264,7 +1273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "source": [
     "#### Adding STAC Layers to the Map"
@@ -1273,7 +1282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1285,7 +1294,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "source": [
     "## Accessing and Visualizing Maxar Open Data\n",
@@ -1296,7 +1305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1305,7 +1314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "source": [
     "### Selecting a Disaster Event"
@@ -1314,7 +1323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1326,7 +1335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1337,7 +1346,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "source": [
     "### Visualizing Image Footprints"
@@ -1346,7 +1355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1357,7 +1366,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "source": [
     "### Temporal Analysis: Before and After the Earthquake"
@@ -1366,7 +1375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "110",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1378,7 +1387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "111",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1389,7 +1398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "112",
+   "id": "113",
    "metadata": {},
    "source": [
     "### Comparing Pre-Event and Post-Event Coverage"
@@ -1398,7 +1407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1417,7 +1426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "source": [
     "### Selecting a Region of Interest"
@@ -1426,7 +1435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1437,7 +1446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "source": [
     "### Searching Within the Region of Interest"
@@ -1446,7 +1455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1457,7 +1466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1467,7 +1476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "source": [
     "### Preparing Images for Visualization"
@@ -1476,7 +1485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1487,7 +1496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1497,7 +1506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "source": [
     "### Creating Web-Optimized Tile Services"
@@ -1506,7 +1515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "123",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1517,7 +1526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1527,7 +1536,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "125",
+   "id": "126",
    "metadata": {},
    "source": [
     "### Creating a Split-Map Comparison"
@@ -1536,7 +1545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "126",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1553,7 +1562,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "127",
+   "id": "128",
    "metadata": {},
    "source": [
     "### Downloading Images for Offline Analysis"
@@ -1562,7 +1571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "128",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1573,7 +1582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1583,7 +1592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1592,7 +1601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "131",
+   "id": "132",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -1605,14 +1614,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "132",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "133",
+   "id": "134",
    "metadata": {},
    "source": [
     "### Exercise 2: Adding XYZ and WMS Tile Layers"
@@ -1621,14 +1630,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "134",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "135",
+   "id": "136",
    "metadata": {},
    "source": [
     "### Exercise 3: Adding Map Legends"
@@ -1637,14 +1646,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "136",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "137",
+   "id": "138",
    "metadata": {},
    "source": [
     "### Exercise 4: Creating Marker Clusters"
@@ -1653,14 +1662,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "138",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "139",
+   "id": "140",
    "metadata": {},
    "source": [
     "### Exercise 5: Visualizing Vector Data"
@@ -1669,14 +1678,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "140",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "141",
+   "id": "142",
    "metadata": {},
    "source": [
     "### Exercise 6: Visualizing GeoParquet Data"
@@ -1685,14 +1694,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "142",
+   "id": "143",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "143",
+   "id": "144",
    "metadata": {},
    "source": [
     "### Exercise 7: Visualizing PMTiles"
@@ -1701,14 +1710,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "144",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "145",
+   "id": "146",
    "metadata": {},
    "source": [
     "### Exercise 8: Visualizing Cloud Optimized GeoTIFFs (COGs)"
@@ -1717,14 +1726,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "146",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "147",
+   "id": "148",
    "metadata": {},
    "source": [
     "### Exercise 9: Visualizing Local Raster Data"
@@ -1733,14 +1742,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "148",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "149",
+   "id": "150",
    "metadata": {},
    "source": [
     "### Exercise 10: Creating a Split Map"
@@ -1749,7 +1758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "150",
+   "id": "151",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/leafmap.md
+++ b/book/geospatial/leafmap.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/leafmap.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/leafmap.ipynb)
+
 # Interactive Visualization with Leafmap
 
 ## Introduction

--- a/book/geospatial/maplibre.ipynb
+++ b/book/geospatial/maplibre.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/maplibre.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/maplibre.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# 3D Mapping with MapLibre\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Creating Interactive Maps\n",
@@ -49,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Customizing the Map's Center and Zoom Level"
@@ -68,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "### Choosing a Basemap Style"
@@ -87,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "### Adding Background Colors"
@@ -117,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +148,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Adding Map Controls\n",
@@ -152,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Adding Fullscreen Control"
@@ -172,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +192,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Adding Navigation Control"
@@ -192,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Adding Draw Control"
@@ -212,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Adding Layers\n",
@@ -307,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Adding XYZ Tile Layer"
@@ -359,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +380,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Adding WMS Layer"
@@ -380,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +419,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Using MapTiler"
@@ -419,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "## 3D Mapping\n",
@@ -484,7 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -498,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,7 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -565,7 +574,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "### 3D Buildings"
@@ -574,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,7 +656,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### 3D Indoor Mapping"
@@ -656,7 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -678,7 +687,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -703,7 +712,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "### 3D Choropleth Map"
@@ -712,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -761,7 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -801,7 +810,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "## Visualizing Vector Data\n",
@@ -812,7 +821,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -824,7 +833,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -836,7 +845,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -849,7 +858,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -862,7 +871,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -886,7 +895,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "#### Customizing Marker Icon Image"
@@ -895,7 +904,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -928,7 +937,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "source": [
     "### Line Data"
@@ -937,7 +946,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -979,7 +988,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "source": [
     "### Polygon Data"
@@ -988,7 +997,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1002,7 +1011,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1018,7 +1027,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "### Multiple Geometries"
@@ -1027,7 +1036,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1060,7 +1069,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "source": [
     "### Marker Cluster"
@@ -1069,7 +1078,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1131,7 +1140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "source": [
     "### Local Vector Data"
@@ -1140,7 +1149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1152,7 +1161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1163,7 +1172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1172,7 +1181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "source": [
     "### Changing Building Color"
@@ -1181,7 +1190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1203,7 +1212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1212,7 +1221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "### Adding a New Layer Below Labels"
@@ -1221,7 +1230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1245,7 +1254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "source": [
     "### Visualizing Population Density"
@@ -1254,7 +1263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1309,7 +1318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "source": [
     "## Visualizing Raster Data\n",
@@ -1320,7 +1329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1332,7 +1341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1346,7 +1355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1358,7 +1367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1369,7 +1378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "source": [
     "### Cloud Optimized GeoTIFF (COG)"
@@ -1378,7 +1387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1397,7 +1406,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "source": [
     "### STAC Layer"
@@ -1406,7 +1415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1421,7 +1430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1432,7 +1441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1442,7 +1451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1458,7 +1467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "source": [
     "## Adding Custom Components\n",
@@ -1469,7 +1478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1507,7 +1516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1520,7 +1529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1532,7 +1541,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "source": [
     "### Adding Text"
@@ -1541,7 +1550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1555,7 +1564,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "source": [
     "### Adding GIF"
@@ -1564,7 +1573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1580,7 +1589,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "source": [
     "### Adding HTML"
@@ -1589,7 +1598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1616,7 +1625,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "source": [
     "### Adding Color bar"
@@ -1625,7 +1634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1635,7 +1644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1659,7 +1668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1686,7 +1695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "110",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1714,7 +1723,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "111",
+   "id": "112",
    "metadata": {},
    "source": [
     "### Adding Legend"
@@ -1723,7 +1732,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "112",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1744,7 +1753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1787,7 +1796,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "source": [
     "### Adding Video"
@@ -1796,7 +1805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1821,7 +1830,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1843,7 +1852,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "source": [
     "## Visualizing PMTiles\n",
@@ -1854,7 +1863,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1867,7 +1876,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1908,7 +1917,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "source": [
     "### Fields of The World"
@@ -1917,7 +1926,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1930,7 +1939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1989,7 +1998,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "123",
+   "id": "124",
    "metadata": {},
    "source": [
     "### 3D PMTiles"
@@ -1998,7 +2007,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2010,7 +2019,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "125",
+   "id": "126",
    "metadata": {},
    "source": [
     "### 3D Buildings"
@@ -2019,7 +2028,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "126",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2039,7 +2048,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "127",
+   "id": "128",
    "metadata": {},
    "source": [
     "### 2D Buildings, Transportation, and Other Themes"
@@ -2048,7 +2057,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "128",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2062,7 +2071,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2076,7 +2085,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2090,7 +2099,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "131",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2104,7 +2113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "132",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2118,7 +2127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "133",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2131,7 +2140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "134",
+   "id": "135",
    "metadata": {},
    "source": [
     "## Adding DeckGL Layers\n",
@@ -2142,7 +2151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "135",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2171,7 +2180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "136",
+   "id": "137",
    "metadata": {},
    "source": [
     "### Multiple DeckGL Layers"
@@ -2180,7 +2189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "137",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2191,7 +2200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "138",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2242,7 +2251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "139",
+   "id": "140",
    "metadata": {},
    "source": [
     "## Exporting to HTML"
@@ -2251,7 +2260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "140",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2263,7 +2272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "141",
+   "id": "142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2283,7 +2292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "142",
+   "id": "143",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -2296,14 +2305,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "143",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "144",
+   "id": "145",
    "metadata": {},
    "source": [
     "### Exercise 2: Customizing the Map View"
@@ -2312,14 +2321,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "145",
+   "id": "146",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "146",
+   "id": "147",
    "metadata": {},
    "source": [
     "### Exercise 3: Adding Map Controls"
@@ -2328,14 +2337,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "147",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "148",
+   "id": "149",
    "metadata": {},
    "source": [
     "### Exercise 4: Overlaying Data Layers"
@@ -2344,14 +2353,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "149",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "150",
+   "id": "151",
    "metadata": {},
    "source": [
     "### Exercise 5: Working with 3D Buildings"
@@ -2360,14 +2369,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "151",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "152",
+   "id": "153",
    "metadata": {},
    "source": [
     "### Exercise 6: Adding Map Elements"
@@ -2376,7 +2385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "153",
+   "id": "154",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/maplibre.md
+++ b/book/geospatial/maplibre.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/maplibre.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/maplibre.ipynb)
+
 # 3D Mapping with MapLibre
 
 ## Introduction

--- a/book/geospatial/rasterio.ipynb
+++ b/book/geospatial/rasterio.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/rasterio.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/rasterio.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Working with Raster Data Using Rasterio\n",
     "\n",
     "## Introduction\n",
@@ -21,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Reading Raster Data\n",
@@ -55,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Understanding Raster Metadata\n",
@@ -79,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,20 +110,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "#### Spatial Properties"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(f\"Coordinate Reference System: {src.crs}\")"
    ]
   },
   {
@@ -124,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"Pixel size (x, y): {src.res}\")"
+    "print(f\"Coordinate Reference System: {src.crs}\")"
    ]
   },
   {
@@ -134,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"Raster dimensions: {src.width} x {src.height} pixels\")"
+    "print(f\"Pixel size (x, y): {src.res}\")"
    ]
   },
   {
@@ -144,25 +143,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"Geographic bounds: {src.bounds}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "13",
-   "metadata": {},
-   "source": [
-    "#### Data Properties"
+    "print(f\"Raster dimensions: {src.width} x {src.height} pixels\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"Data types: {src.dtypes}\")"
+    "print(f\"Geographic bounds: {src.bounds}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "#### Data Properties"
    ]
   },
   {
@@ -172,12 +171,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "print(f\"Data types: {src.dtypes}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "print(f\"Number of bands: {src.count}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### The Affine Transform"
@@ -186,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Visualizing Raster Data\n",
@@ -207,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Understanding Color Maps"
@@ -225,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Adding Colorbars"
@@ -245,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Visualizing Multiple Bands"
@@ -268,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +287,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "#### Single Band Visualization"
@@ -287,7 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "#### RGB Composite"
@@ -305,7 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "#### Creating a Multi-Panel Plot"
@@ -334,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Overlaying Vector Data"
@@ -365,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Accessing and Manipulating Raster Bands\n",
@@ -402,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -413,7 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,7 +438,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Basic Band Math (NDVI Calculation)"
@@ -438,7 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,7 +466,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "## Writing Raster Data"
@@ -466,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -502,7 +511,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## Clipping Raster Data\n",
@@ -513,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,7 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -603,7 +612,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "### Clipping with a Vector Dataset"
@@ -612,7 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +643,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -658,7 +667,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -678,7 +687,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -693,14 +702,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "### Exercise 2: Working with Raster Bands"
@@ -709,14 +718,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "source": [
     "### Exercise 3: Basic Raster Operations"
@@ -725,14 +734,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "### Exercise 4: Writing and Saving Raster Data"
@@ -741,14 +750,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "source": [
     "### Exercise 5: Clipping and Subsetting"
@@ -757,7 +766,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/rasterio.md
+++ b/book/geospatial/rasterio.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/rasterio.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/rasterio.ipynb)
+
 # Working with Raster Data Using Rasterio
 
 ## Introduction

--- a/book/geospatial/rioxarray.ipynb
+++ b/book/geospatial/rioxarray.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/rioxarray.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/rioxarray.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Raster Analysis with Rioxarray\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Importing Libraries and Configuration"
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Loading and Exploring Georeferenced Raster Data\n",
@@ -68,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Exploring the Dataset Structure"
@@ -90,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "### Accessing Spatial Reference Information"
@@ -138,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Setting CRS When Missing"
@@ -171,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Fundamental Geospatial Operations\n",
@@ -193,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Spatial Subsetting with Bounding Boxes"
@@ -221,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Vector-Based Clipping"
@@ -246,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Working with Spatial Dimensions and Resolution\n",
@@ -277,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "### Resampling to Different Resolutions"
@@ -309,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +340,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Spatial Subsetting by Coordinates"
@@ -340,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "## Visualizing Geospatial Raster Data\n",
@@ -372,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +407,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Visualizing Individual Bands"
@@ -407,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +443,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Overlaying Vector Data on Raster Images"
@@ -443,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,7 +484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "## Data Storage and File Management\n",
@@ -486,7 +495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +529,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "### Managing NoData Values"
@@ -529,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "## Coordinate System Comparisons"
@@ -566,7 +575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -595,7 +604,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "### Side-by-Side Coordinate System Visualization"
@@ -604,7 +613,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## Introduction to Band Math\n",
@@ -640,7 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +679,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### Visualizing Vegetation Analysis"
@@ -679,7 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -719,7 +728,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### Interpreting NDVI Results"
@@ -728,7 +737,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -753,7 +762,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -768,14 +777,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "### Exercise 2: Coordinate System Transformation"
@@ -784,14 +793,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "### Exercise 3: Spatial Subsetting with Bounding Boxes"
@@ -800,14 +809,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "### Exercise 4: Vector-Based Masking"
@@ -816,14 +825,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "source": [
     "### Exercise 5: Resolution Analysis and Data Export"
@@ -832,7 +841,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/rioxarray.md
+++ b/book/geospatial/rioxarray.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/rioxarray.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/rioxarray.ipynb)
+
 # Raster Analysis with Rioxarray
 
 ## Introduction

--- a/book/geospatial/sedona.ipynb
+++ b/book/geospatial/sedona.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/sedona.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/sedona.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Distributed Computing with Apache Sedona\n",
     "\n",
     "## Introduction\n",
@@ -25,7 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Creating a Sedona-Enabled Spark Session"
@@ -47,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Downloading Sample Data"
@@ -99,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Core Concepts and Data Structures\n",
@@ -126,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Working with Real Geospatial Data"
@@ -162,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Spatial Operations and Functions\n",
@@ -211,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Distance Calculations"
@@ -241,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Spatial Relationships"
@@ -307,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Spatial Joins and Indexing\n",
@@ -348,7 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +386,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Spatial Join Example: Cities by Country"
@@ -386,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Advanced Spatial Analysis\n",
@@ -444,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Spatial Clustering Analysis"
@@ -481,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -517,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "## Reading Vector Data\n",
@@ -528,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,7 +555,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Reading GeoJSON"
@@ -555,7 +564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -567,7 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,7 +597,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Reading Shapefiles"
@@ -597,7 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +617,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "### Reading GeoPackage"
@@ -617,7 +626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +641,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Reading GeoParquet"
@@ -641,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -664,7 +673,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Reading Cloud-Stored Data"
@@ -673,7 +682,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -685,7 +694,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -696,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -708,7 +717,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -720,7 +729,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,7 +740,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "## Visualizing Vector Data\n",
@@ -742,7 +751,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,7 +772,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +783,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -784,7 +793,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "### Using PyDeck"
@@ -793,7 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -805,7 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -816,7 +825,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "## Writing Vector Data"
@@ -825,7 +834,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -838,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -849,7 +858,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -861,7 +870,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,7 +881,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "## Reading Raster Data\n",
@@ -883,7 +892,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -901,7 +910,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -912,7 +921,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "source": [
     "### Reading GeoTIFF"
@@ -921,7 +930,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -932,7 +941,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -942,7 +951,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -953,7 +962,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -964,7 +973,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -974,7 +983,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "## Visualizing Raster Data"
@@ -983,7 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -994,20 +1003,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "## Raster Map Algebra"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "70",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dem_df.printSchema()"
    ]
   },
   {
@@ -1017,13 +1016,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dem_df.createOrReplaceTempView(\"dem_df\")"
+    "dem_df.printSchema()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem_df.createOrReplaceTempView(\"dem_df\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1042,7 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1053,7 +1062,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1065,7 +1074,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1081,7 +1090,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "source": [
     "## Raster Zonal Statistics"
@@ -1090,7 +1099,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1101,7 +1110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1112,7 +1121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1129,7 +1138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1139,7 +1148,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "source": [
     "## Writing Raster Data"
@@ -1148,7 +1157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1169,7 +1178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1187,7 +1196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1200,7 +1209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "source": [
     "## Integration with GeoPandas\n",
@@ -1211,7 +1220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1228,7 +1237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1241,7 +1250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1250,7 +1259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "source": [
     "### From Sedona DataFrame To GeoArrow"
@@ -1259,7 +1268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1270,7 +1279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "source": [
     "### From GeoPandas GeoDataFrame to Sedona DataFrame"
@@ -1279,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1291,7 +1300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1302,7 +1311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1314,7 +1323,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "source": [
     "### Advanced Integration: Converting Through GeoArrow"
@@ -1323,7 +1332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1334,7 +1343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1345,7 +1354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1356,7 +1365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1367,7 +1376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "source": [
     "### Custom Conversion Functions"
@@ -1376,7 +1385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1410,7 +1419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1420,7 +1429,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "source": [
     "## Real-World Use Cases\n",
@@ -1431,7 +1440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1464,7 +1473,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "source": [
     "### Use Case 2: Transit Accessibility Assessment"
@@ -1473,7 +1482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1505,7 +1514,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -1520,14 +1529,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "source": [
     "### Exercise 2: Working with Real Geospatial Data"
@@ -1536,14 +1545,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "110",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "111",
+   "id": "112",
    "metadata": {},
    "source": [
     "### Exercise 3: Distance Analysis"
@@ -1552,14 +1561,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "112",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "source": [
     "### Exercise 4: Spatial Joins"
@@ -1568,14 +1577,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "source": [
     "### Exercise 5: Spatial Aggregation and Clustering"
@@ -1584,14 +1593,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "source": [
     "### Exercise 6: Buffer Analysis"
@@ -1600,14 +1609,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "source": [
     "### Exercise 7: Spatial SQL Queries"
@@ -1616,14 +1625,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "source": [
     "### Exercise 8: Advanced Spatial Analysis"
@@ -1632,7 +1641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/sedona.md
+++ b/book/geospatial/sedona.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/sedona.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/sedona.ipynb)
+
 # Distributed Computing with Apache Sedona
 
 ## Introduction

--- a/book/geospatial/solara.ipynb
+++ b/book/geospatial/solara.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/solara.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/solara.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Building Interactive Dashboards with Voilà and Solara\n",
     "\n",
     "## Introduction\n",
@@ -17,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Introduction to Hugging Face Spaces\n",
@@ -48,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Logging in to Hugging Face\n",
@@ -78,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "### Exploring the File Structure of the Space\n",
@@ -135,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +175,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Creating a New Page"
@@ -175,7 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Running the Solara Web App Locally\n",

--- a/book/geospatial/solara.md
+++ b/book/geospatial/solara.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/solara.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/solara.ipynb)
+
 # Building Interactive Dashboards with Voilà and Solara
 
 ## Introduction

--- a/book/geospatial/whitebox.ipynb
+++ b/book/geospatial/whitebox.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/whitebox.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/whitebox.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Geoprocessing with WhiteboxTools\n",
     "\n",
     "## Introduction\n",
@@ -27,7 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Watershed Analysis\n",
@@ -69,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Download Watershed Data"
@@ -91,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "### Download and Display DEM"
@@ -136,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Get DEM metadata"
@@ -173,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,20 +192,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Add colorbar"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "leafmap.image_min_max(\"dem.tif\")"
    ]
   },
   {
@@ -206,26 +205,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "leafmap.image_min_max(\"dem.tif\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "m.add_colormap(cmap=\"terrain\", vmin=\"60\", vmax=1500, label=\"Elevation (m)\")\n",
     "m"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Initialize WhiteboxTools"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "19",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wbt = leafmap.WhiteboxTools()"
    ]
   },
   {
@@ -235,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wbt.version()"
+    "wbt = leafmap.WhiteboxTools()"
    ]
   },
   {
@@ -245,12 +244,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "wbt.version()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "leafmap.whiteboxgui()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Initialize WhiteboxTools\n",
@@ -261,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Smooth DEM"
@@ -280,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,20 +313,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "### Create hillshade"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "28",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wbt.hillshade(\"smoothed.tif\", \"hillshade.tif\", azimuth=315, altitude=35)"
    ]
   },
   {
@@ -327,26 +326,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "wbt.hillshade(\"smoothed.tif\", \"hillshade.tif\", azimuth=315, altitude=35)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "m.add_raster(\"hillshade.tif\", layer_name=\"Hillshade\")\n",
     "m.layers[-1].opacity = 0.6"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Find no-flow cells"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "31",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wbt.find_no_flow_cells(\"smoothed.tif\", \"noflow.tif\")"
    ]
   },
   {
@@ -356,25 +355,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.add_raster(\"noflow.tif\", layer_name=\"No Flow Cells\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "33",
-   "metadata": {},
-   "source": [
-    "### Fill depressions"
+    "wbt.find_no_flow_cells(\"smoothed.tif\", \"noflow.tif\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
-    "wbt.fill_depressions(\"smoothed.tif\", \"filled.tif\")"
+    "m.add_raster(\"noflow.tif\", layer_name=\"No Flow Cells\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34",
+   "metadata": {},
+   "source": [
+    "### Fill depressions"
    ]
   },
   {
@@ -384,7 +383,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wbt.breach_depressions(\"smoothed.tif\", \"breached.tif\")"
+    "wbt.fill_depressions(\"smoothed.tif\", \"filled.tif\")"
    ]
   },
   {
@@ -394,13 +393,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wbt.find_no_flow_cells(\"breached.tif\", \"noflow2.tif\")"
+    "wbt.breach_depressions(\"smoothed.tif\", \"breached.tif\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wbt.find_no_flow_cells(\"breached.tif\", \"noflow2.tif\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +420,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "### Delineate flow direction"
@@ -420,7 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,20 +438,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Calculate flow accumulation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wbt.d8_flow_accumulation(\"breached.tif\", \"flow_accum.tif\")"
    ]
   },
   {
@@ -452,12 +451,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "wbt.d8_flow_accumulation(\"breached.tif\", \"flow_accum.tif\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "m.add_raster(\"flow_accum.tif\", layer_name=\"Flow Accumulation\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "### Extract streams"
@@ -466,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +496,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "### Calculate distance to outlet"
@@ -496,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -517,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### Vectorize streams"
@@ -526,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +572,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "### Delineate the longest flow path"
@@ -572,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,7 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +603,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,7 +615,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "### Generate a pour point"
@@ -629,7 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,7 +653,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "source": [
     "### Snap pour point to stream"
@@ -653,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -674,20 +683,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "### Delineate watershed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "64",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wbt.watershed(\"flow_direction.tif\", \"pour_point_snapped.shp\", \"watershed.tif\")"
    ]
   },
   {
@@ -697,13 +696,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "wbt.watershed(\"flow_direction.tif\", \"pour_point_snapped.shp\", \"watershed.tif\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "m.add_raster(\"watershed.tif\", layer_name=\"Watershed\")\n",
     "m"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "source": [
     "### Convert watershed raster to vector"
@@ -712,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,7 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -737,7 +746,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "## LiDAR Data Analysis\n",
@@ -748,7 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +768,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "source": [
     "### Download a sample dataset"
@@ -768,7 +777,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -779,7 +788,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "source": [
     "### Read LAS/LAZ data"
@@ -788,7 +797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -808,7 +817,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "source": [
     "### Upgrade file version"
@@ -817,7 +826,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -827,7 +836,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "source": [
     "### Write LAS data"
@@ -836,7 +845,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -845,7 +854,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "### Histogram analysis"
@@ -854,7 +863,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -863,7 +872,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "source": [
     "### Visualize LiDAR data"
@@ -872,7 +881,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -881,7 +890,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "source": [
     "### Remove outliers"
@@ -890,7 +899,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -899,7 +908,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "source": [
     "### Visualize LiDAR data after removing outliers"
@@ -908,7 +917,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -917,7 +926,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "source": [
     "### Create DSM"
@@ -926,7 +935,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -938,7 +947,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -947,7 +956,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "source": [
     "### Visualize DSM"
@@ -956,7 +965,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,7 +977,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "source": [
     "### Create DEM"
@@ -977,7 +986,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -986,7 +995,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "source": [
     "### Visualize DEM"
@@ -995,7 +1004,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1005,7 +1014,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "source": [
     "### Create CHM"
@@ -1014,7 +1023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1024,7 +1033,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1035,7 +1044,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",

--- a/book/geospatial/whitebox.md
+++ b/book/geospatial/whitebox.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/whitebox.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/whitebox.ipynb)
+
 # Geoprocessing with WhiteboxTools
 
 ## Introduction

--- a/book/geospatial/xarray.ipynb
+++ b/book/geospatial/xarray.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/xarray.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/xarray.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Multi-dimensional Data Analysis with Xarray\n",
     "\n",
     "## Introduction\n",
@@ -25,7 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Importing Libraries and Configuration"
@@ -43,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Loading and Exploring Real Climate Data\n",
@@ -74,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Working with DataArrays\n",
@@ -96,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +128,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Exploring DataArray Components"
@@ -128,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Intuitive Data Selection and Indexing\n",
@@ -189,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Time Range Selection"
@@ -209,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Nearest Neighbor Selection"
@@ -230,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Performing Operations on Multi-Dimensional Data\n",
@@ -254,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Computing Anomalies"
@@ -278,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +303,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Spatial Statistics"
@@ -303,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "## Data Visualization with Xarray\n",
@@ -331,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -347,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Customizing Spatial Plots"
@@ -356,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Time Series Visualization"
@@ -388,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "## Working with Datasets: Multiple Variables\n",
@@ -418,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Dataset-Level Operations"
@@ -442,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "## The Power of Label-Based Operations\n",
@@ -464,7 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +508,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "### The Xarray Approach: Label-Based Selection"
@@ -508,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,7 +542,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "## Advanced Indexing Techniques\n",
@@ -544,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,7 +568,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Boolean Indexing and Conditional Selection"
@@ -568,7 +577,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "## High-Level Computational Operations\n",
@@ -596,7 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### Rolling Window Operations"
@@ -640,7 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +676,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "### Weighted Operations"
@@ -676,7 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,7 +709,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "## Data Input and Output\n",
@@ -713,7 +722,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +741,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "### Reading Data from NetCDF"
@@ -741,7 +750,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -755,7 +764,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -770,14 +779,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "source": [
     "### Exercise 2: Data Selection and Indexing"
@@ -786,14 +795,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "source": [
     "### Exercise 3: Performing Arithmetic Operations"
@@ -802,14 +811,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "### Exercise 4: GroupBy and Temporal Analysis"
@@ -818,14 +827,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "### Exercise 5: Data Storage and Retrieval"
@@ -834,7 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/geospatial/xarray.md
+++ b/book/geospatial/xarray.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/geospatial/xarray.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/geospatial/xarray.ipynb)
+
 # Multi-dimensional Data Analysis with Xarray
 
 ## Introduction

--- a/book/preface.ipynb
+++ b/book/preface.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/preface.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/preface.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Preface\n",
     "\n",
     "## Introduction\n",
@@ -100,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "**Command Line Instructions**: Commands to be entered at the command line or terminal are shown with a `$` prompt:\n",

--- a/book/preface.md
+++ b/book/preface.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/preface.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/preface.ipynb)
+
 # Preface
 
 ## Introduction

--- a/book/python/data-structures.ipynb
+++ b/book/python/data-structures.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/data-structures.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/data-structures.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Python Data Structures\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +41,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Accessing Tuple Elements"
@@ -41,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Tuple Unpacking"
@@ -62,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Multiple Coordinate Points"
@@ -81,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Lists\n",
@@ -108,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Adding Elements to Lists"
@@ -156,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Accessing List Elements"
@@ -188,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "### List Slicing"
@@ -212,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Useful List Operations"
@@ -236,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Sets\n",
@@ -266,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Adding Elements to Sets"
@@ -312,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "### Practical Set Operations"
@@ -337,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +372,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Checking Set Membership"
@@ -372,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "## Dictionaries\n",
@@ -399,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +444,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Accessing Dictionary Values"
@@ -444,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +469,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "### Safe Access with get()"
@@ -469,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "### Adding and Updating Values"
@@ -492,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +515,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Working with Geographic Feature Collections"
@@ -515,7 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,7 +555,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "### Dictionary Methods for Data Exploration"
@@ -555,7 +564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,7 +583,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Practical Example: GPS Waypoint Management"
@@ -583,7 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +617,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "## Data Structure Selection Guide\n",
@@ -625,14 +634,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Exercise 2: Using Tuples"
@@ -641,14 +650,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "### Exercise 3: Working with Sets"
@@ -657,14 +666,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "source": [
     "### Exercise 4: Working with Dictionaries"
@@ -673,14 +682,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "### Exercise 5: Nested Data Structures"
@@ -689,7 +698,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/python/data-structures.md
+++ b/book/python/data-structures.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/data-structures.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/data-structures.ipynb)
+
 # Python Data Structures
 
 ## Introduction

--- a/book/python/files.ipynb
+++ b/book/python/files.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/files.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/files.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Working with Files\n",
     "\n",
     "## Introduction\n",
@@ -17,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Reading and Writing Files"
@@ -48,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Exception Handling"
@@ -94,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Combining File Handling and Exception Handling"
@@ -156,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Working with Different File Formats"
@@ -230,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -326,14 +335,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Exercise 2: Processing Coordinates from a File"
@@ -342,7 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,14 +375,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Exercise 3: Exception Handling in Data Processing"
@@ -382,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/python/files.md
+++ b/book/python/files.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/files.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/files.ipynb)
+
 # Working with Files
 
 ## Introduction

--- a/book/python/functions-classes.ipynb
+++ b/book/python/functions-classes.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/functions-classes.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/functions-classes.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Functions and Classes\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Parameters with Default Values"
@@ -43,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Understanding Function Calls"
@@ -67,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Geospatial Example: Haversine Function"
@@ -92,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Function with Default Values and Geospatial Application"
@@ -135,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Processing Multiple Coordinates"
@@ -171,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Advanced Parameter Handling\n",
@@ -204,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "#### Keyword Arguments with \\*\\*kwargs"
@@ -228,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Classes: Organizing Data and Behavior Together\n",
@@ -260,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +290,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Adding Methods to a Class"
@@ -290,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +325,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Constructor with Default Values"
@@ -325,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +347,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "## Combining Functions and Classes"
@@ -347,7 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "## Function and Class Design Guidelines\n",
@@ -384,14 +393,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "### Exercise 2: Batch Distance Calculation"
@@ -400,14 +409,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Exercise 3: Creating and Using a Point Class"
@@ -416,7 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/python/functions-classes.md
+++ b/book/python/functions-classes.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/functions-classes.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/functions-classes.ipynb)
+
 # Functions and Classes
 
 ## Introduction

--- a/book/python/looping.ipynb
+++ b/book/python/looping.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/looping.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/looping.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Loops and Conditional Statements\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Processing Multiple Data Points"
@@ -44,7 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Iterating Through Geographic Collections"
@@ -71,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## While Loops\n",
@@ -96,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +118,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Practical While Loop Example"
@@ -118,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Control Statements: Making Decisions in Your Code\n",
@@ -161,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Multiple Conditions and Complex Logic"
@@ -185,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Logical Operators for Complex Conditions"
@@ -216,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Combining Loops and Control Statements"
@@ -245,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Counting and Analyzing Data"
@@ -267,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Building Summary Statistics"
@@ -289,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "## Loop and Control Statement Decision Guide\n",
@@ -358,14 +367,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Exercise 2: While Loops for Iterative Processing"
@@ -374,14 +383,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Exercise 3: Conditional Logic in Loops"
@@ -390,14 +399,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Exercise 4: Filtering Data with Combined Loops and Conditionals"
@@ -406,14 +415,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Exercise 5: Generating and Analyzing Random Coordinates"
@@ -422,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/python/looping.md
+++ b/book/python/looping.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/looping.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/looping.ipynb)
+
 # Loops and Conditional Statements
 
 ## Introduction

--- a/book/python/numpy-pandas.ipynb
+++ b/book/python/numpy-pandas.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/numpy-pandas.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/numpy-pandas.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Data Analysis with NumPy and Pandas\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "### Basic Array Operations"
@@ -115,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Reshaping Arrays"
@@ -183,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Mathematical Functions on Arrays"
@@ -232,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +284,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Statistical Operations"
@@ -284,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Random Data Generation for Simulation"
@@ -322,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Indexing, Slicing, and Iterating\n",
@@ -372,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +431,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "#### Slicing in NumPy"
@@ -431,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,7 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +486,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "#### Boolean Indexing"
@@ -486,7 +495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "#### Iterating Over Arrays"
@@ -513,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,7 +558,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "### Modifying Array Elements"
@@ -558,7 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -576,7 +585,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Working with Geospatial Coordinates"
@@ -585,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -599,7 +608,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "## Introduction to Pandas\n",
@@ -610,7 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -655,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -664,7 +673,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Basic DataFrame Operations"
@@ -673,7 +682,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -699,7 +708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -711,7 +720,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -726,7 +735,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +757,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "### Grouping and Aggregation"
@@ -757,7 +766,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -773,7 +782,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +792,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "### Merging DataFrames"
@@ -792,7 +801,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -810,7 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -820,7 +829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -830,7 +839,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -841,7 +850,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "source": [
     "### Handling Missing Data"
@@ -850,7 +859,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -865,7 +874,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -875,7 +884,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "### Reading Geospatial Data from a CSV File"
@@ -884,7 +893,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -896,7 +905,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -905,7 +914,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "### Creating plots with Pandas"
@@ -914,7 +923,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -929,7 +938,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -942,7 +951,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -952,7 +961,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -962,7 +971,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -972,7 +981,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -981,7 +990,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "source": [
     "## Combining NumPy and Pandas"
@@ -990,7 +999,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1034,7 +1043,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -1049,14 +1058,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "source": [
     "### Exercise 2: Pandas DataFrame Operations with Geospatial Data"
@@ -1065,7 +1074,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/python/numpy-pandas.md
+++ b/book/python/numpy-pandas.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/numpy-pandas.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/numpy-pandas.ipynb)
+
 # Data Analysis with NumPy and Pandas
 
 ## Introduction

--- a/book/python/string-operations.ipynb
+++ b/book/python/string-operations.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/string-operations.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/string-operations.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# String Operations\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### String Concatenation"
@@ -45,7 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "### String Repetition"
@@ -71,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "### String Length and Basic Properties"
@@ -98,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Building Dynamic Content"
@@ -126,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## String Methods for Geospatial Data\n",
@@ -163,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Whitespace Removal Methods"
@@ -189,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### String Replacement"
@@ -215,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### String Splitting"
@@ -243,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +300,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "### String Joining"
@@ -300,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +347,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "## String Formatting\n",
@@ -349,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Formatting Numbers in Strings"
@@ -383,7 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Legacy Formatting Methods"
@@ -417,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +452,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Practical Formatting Examples"
@@ -452,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +503,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "## String Operation Decision Guide\n",
@@ -511,14 +520,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "### Exercise 2: Extracting and Formatting Coordinates"
@@ -527,14 +536,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Exercise 3: Building Dynamic SQL Queries"
@@ -543,14 +552,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "### Exercise 4: String Normalization and Cleaning"
@@ -559,14 +568,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "### Exercise 5: Parsing and Extracting Address Information"
@@ -575,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/python/string-operations.md
+++ b/book/python/string-operations.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/string-operations.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/string-operations.ipynb)
+
 # String Operations
 
 ## Introduction

--- a/book/python/variables.ipynb
+++ b/book/python/variables.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/variables.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/variables.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Variables and Data Types\n",
     "\n",
     "## Introduction\n",
@@ -17,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Variable Assignment"
@@ -55,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Naming Variables\n",
@@ -84,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Poor Naming Examples to Avoid"
@@ -108,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Data Types"
@@ -130,7 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,20 +207,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Escape Characters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "18",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"Hello World!\\nThis is a Python script.\")"
    ]
   },
   {
@@ -221,7 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"This is the first line.\\n\\tThis is the second line. It is indented.\")"
+    "print(\"Hello World!\\nThis is a Python script.\")"
    ]
   },
   {
@@ -231,7 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"What's your name?\")"
+    "print(\"This is the first line.\\n\\tThis is the second line. It is indented.\")"
    ]
   },
   {
@@ -245,8 +244,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"What's your name?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23",
    "metadata": {},
    "source": [
     "## Comments in Python"
@@ -255,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +274,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Working with Variables and Data Types"
@@ -274,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "## Basic String Operations\n",
@@ -334,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +364,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Replacing Text"
@@ -364,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +385,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Other Useful String Methods"
@@ -385,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +407,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -411,14 +420,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Exercise 2: Working with Strings"
@@ -427,7 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/python/variables.md
+++ b/book/python/variables.md
@@ -10,6 +10,10 @@ kernelspec:
   display_name: Python 3
   language: python
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/python/variables.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/python/variables.ipynb)
+
 # Variables and Data Types
 
 ## Introduction

--- a/book/software/colab.ipynb
+++ b/book/software/colab.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/colab.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/colab.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Using Google Colab\n",
     "\n",
     "## Introduction\n",

--- a/book/software/colab.md
+++ b/book/software/colab.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/colab.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/colab.ipynb)
+
 # Using Google Colab
 
 ## Introduction

--- a/book/software/conda.ipynb
+++ b/book/software/conda.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/conda.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/conda.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Introduction to Python Package Management\n",
     "\n",
     "## Introduction\n",

--- a/book/software/conda.md
+++ b/book/software/conda.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/conda.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/conda.ipynb)
+
 # Introduction to Python Package Management
 
 ## Introduction

--- a/book/software/docker.ipynb
+++ b/book/software/docker.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/docker.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/docker.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Using Docker\n",
     "\n",
     "## Introduction\n",
@@ -111,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +146,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Exercise 3: Working with Different Ports\n",

--- a/book/software/docker.md
+++ b/book/software/docker.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/docker.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/docker.ipynb)
+
 # Using Docker
 
 ## Introduction

--- a/book/software/git.ipynb
+++ b/book/software/git.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/git.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/git.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Version Control with Git\n",
     "\n",
     "## Introduction\n",

--- a/book/software/git.md
+++ b/book/software/git.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/git.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/git.ipynb)
+
 # Version Control with Git
 
 ## Introduction

--- a/book/software/jupyterlab.ipynb
+++ b/book/software/jupyterlab.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/jupyterlab.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/jupyterlab.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Working with JupyterLab\n",
     "\n",
     "## Introduction\n",

--- a/book/software/jupyterlab.md
+++ b/book/software/jupyterlab.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/jupyterlab.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/jupyterlab.ipynb)
+
 # Working with JupyterLab
 
 ## Introduction

--- a/book/software/overview.ipynb
+++ b/book/software/overview.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/overview.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/overview.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Overview of Software Tools\n",
     "\n",
     "## Introduction\n",

--- a/book/software/overview.md
+++ b/book/software/overview.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/overview.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/overview.ipynb)
+
 # Overview of Software Tools
 
 ## Introduction

--- a/book/software/vscode.ipynb
+++ b/book/software/vscode.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/vscode.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/vscode.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Setting Up Visual Studio Code\n",
     "\n",
     "## Introduction\n",
@@ -33,7 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +51,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Essential Keyboard Shortcuts\n",

--- a/book/software/vscode.md
+++ b/book/software/vscode.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/intro-gispro/blob/main/book/software/vscode.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/intro-gispro/main?urlpath=lab/tree/book/software/vscode.ipynb)
+
 # Setting Up Visual Studio Code
 
 ## Introduction

--- a/myst.yml
+++ b/myst.yml
@@ -10,12 +10,12 @@ project:
     - .DS_Store
     - "**.ipynb_checkpoints"
   github: giswqs/intro-gispro
-  thebe:
-    binder:
-      repo: giswqs/intro-gispro
-      provider: github
-      url: https://mybinder.org
-      ref: main
+  # thebe:
+  #   binder:
+  #     repo: giswqs/intro-gispro
+  #     provider: github
+  #     url: https://mybinder.org
+  #     ref: main
   bibliography:
     - book/references.bib
   toc:

--- a/scripts/add_colab_badge.py
+++ b/scripts/add_colab_badge.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Add Google Colab and Binder launch badges to chapter pages and notebooks.
+
+Inserts a Colab + Binder badge block near the top of every chapter Markdown
+file that has a sibling Jupyter notebook, and prepends a matching badge cell
+to every notebook under the book directory. Each badge deep-links to the
+specific ``.ipynb``:
+
+* Colab: ``colab.research.google.com/github/<owner>/<repo>/blob/<branch>/<path>``
+* Binder: ``mybinder.org/v2/gh/<owner>/<repo>/<branch>?urlpath=lab/tree/<path>``
+
+The script is idempotent: a file already containing either badge is left
+unchanged. By default the GitHub slug is read from ``project.github`` in
+``myst.yml``.
+
+Usage:
+    python scripts/add_colab_badge.py --dry-run
+    python scripts/add_colab_badge.py
+    python scripts/add_colab_badge.py --repo giswqs/GeoAI-Book --branch main
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import nbformat
+
+COLAB_BADGE_SVG = "https://colab.research.google.com/assets/colab-badge.svg"
+BINDER_BADGE_SVG = "https://mybinder.org/badge_logo.svg"
+COLAB_OPEN_PREFIX = "https://colab.research.google.com/github/"
+BINDER_OPEN_PREFIX = "https://mybinder.org/v2/gh/"
+FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)
+
+
+def make_badges(repo: str, branch: str, notebook_path: str) -> str:
+    """Return the Markdown snippet for the Colab and Binder launch badges.
+
+    Args:
+        repo: GitHub ``owner/name`` slug.
+        branch: Branch or ref to link to.
+        notebook_path: Repo-relative POSIX path to the ``.ipynb`` file.
+
+    Returns:
+        A two-line Markdown block: one badge per line.
+    """
+    colab_url = f"{COLAB_OPEN_PREFIX}{repo}/blob/{branch}/{notebook_path}"
+    binder_url = f"{BINDER_OPEN_PREFIX}{repo}/{branch}?urlpath=lab/tree/{notebook_path}"
+    return (
+        f"[![image]({COLAB_BADGE_SVG})]({colab_url})\n"
+        f"[![image]({BINDER_BADGE_SVG})]({binder_url})"
+    )
+
+
+def has_launch_badge(text: str) -> bool:
+    """Return True if ``text`` already contains a Colab or Binder badge."""
+    return COLAB_BADGE_SVG in text or BINDER_BADGE_SVG in text
+
+
+def insert_badges_into_markdown(md_text: str, badges: str) -> str:
+    """Insert ``badges`` after the YAML frontmatter, before the body.
+
+    Args:
+        md_text: Original Markdown content.
+        badges: Badge block to inject.
+
+    Returns:
+        New Markdown content with the badges inserted as their own paragraph.
+    """
+    match = FRONTMATTER_RE.match(md_text)
+    if match:
+        head = match.group(0)
+        rest = md_text[match.end() :].lstrip("\n")
+        return f"{head}\n{badges}\n\n{rest}"
+    return f"{badges}\n\n{md_text.lstrip()}"
+
+
+def process_markdown(
+    md_path: Path,
+    repo: str,
+    branch: str,
+    project_root: Path,
+    dry_run: bool,
+) -> str:
+    """Add Colab and Binder badges to a Markdown file paired with a notebook.
+
+    Args:
+        md_path: Markdown file to update.
+        repo: GitHub ``owner/name`` slug.
+        branch: Branch or ref to link to.
+        project_root: Repo root used to compute the relative notebook path.
+        dry_run: If True, do not write changes.
+
+    Returns:
+        One of ``"added"``, ``"skipped"``, ``"no-notebook"``.
+    """
+    nb_path = md_path.with_suffix(".ipynb")
+    if not nb_path.exists():
+        return "no-notebook"
+    text = md_path.read_text(encoding="utf-8")
+    if has_launch_badge(text):
+        return "skipped"
+    rel = nb_path.relative_to(project_root).as_posix()
+    new_text = insert_badges_into_markdown(text, make_badges(repo, branch, rel))
+    if not dry_run:
+        md_path.write_text(new_text, encoding="utf-8")
+    return "added"
+
+
+def process_notebook(
+    nb_path: Path,
+    repo: str,
+    branch: str,
+    project_root: Path,
+    dry_run: bool,
+) -> str:
+    """Prepend a Colab + Binder badge cell to a notebook.
+
+    Args:
+        nb_path: Notebook file to update.
+        repo: GitHub ``owner/name`` slug.
+        branch: Branch or ref to link to.
+        project_root: Repo root used to compute the relative notebook path.
+        dry_run: If True, do not write changes.
+
+    Returns:
+        ``"added"`` or ``"skipped"``.
+    """
+    nb = nbformat.read(nb_path, as_version=4)
+    existing = "\n".join(
+        cell.get("source", "")
+        for cell in nb.cells
+        if cell.get("cell_type") == "markdown"
+    )
+    if has_launch_badge(existing):
+        return "skipped"
+    rel = nb_path.relative_to(project_root).as_posix()
+    badge_cell = nbformat.v4.new_markdown_cell(make_badges(repo, branch, rel))
+    nb.cells.insert(0, badge_cell)
+    if not dry_run:
+        nbformat.write(nb, nb_path)
+    return "added"
+
+
+def repo_from_myst_yml(project_root: Path) -> str | None:
+    """Best-effort extraction of ``project.github`` from ``myst.yml``."""
+    p = project_root / "myst.yml"
+    if not p.exists():
+        return None
+    for line in p.read_text(encoding="utf-8").splitlines():
+        m = re.match(r"\s*github:\s*(\S+)", line)
+        if m:
+            slug = m.group(1).strip().strip("\"'")
+            slug = slug.removeprefix("https://github.com/").rstrip("/")
+            return slug
+    return None
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Project root (defaults to the repository root).",
+    )
+    parser.add_argument(
+        "--book-dir",
+        default="book",
+        help="Directory under root to scan (default: book).",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub owner/repo slug (default: read from myst.yml).",
+    )
+    parser.add_argument(
+        "--branch",
+        default="main",
+        help="Branch or ref used in the Colab URL (default: main).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report planned changes without modifying any files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point. Returns a process exit code."""
+    args = parse_args()
+    root = args.root.resolve()
+    book = root / args.book_dir
+    if not book.is_dir():
+        print(f"error: {book} is not a directory", file=sys.stderr)
+        return 1
+
+    repo = args.repo or repo_from_myst_yml(root)
+    if not repo:
+        print(
+            "error: --repo not given and could not infer it from myst.yml",
+            file=sys.stderr,
+        )
+        return 1
+
+    md_results: dict[str, list[str]] = {
+        "added": [],
+        "skipped": [],
+        "no-notebook": [],
+    }
+    for md in sorted(book.rglob("*.md")):
+        outcome = process_markdown(md, repo, args.branch, root, args.dry_run)
+        md_results[outcome].append(md.relative_to(root).as_posix())
+
+    nb_results: dict[str, list[str]] = {"added": [], "skipped": []}
+    for nb in sorted(book.rglob("*.ipynb")):
+        if ".ipynb_checkpoints" in nb.parts:
+            continue
+        outcome = process_notebook(nb, repo, args.branch, root, args.dry_run)
+        nb_results[outcome].append(nb.relative_to(root).as_posix())
+
+    prefix = "[dry-run] " if args.dry_run else ""
+    print(
+        f"{prefix}Markdown: added={len(md_results['added'])}, "
+        f"skipped={len(md_results['skipped'])}, "
+        f"no-notebook={len(md_results['no-notebook'])}"
+    )
+    for path in md_results["added"]:
+        print(f"  + {path}")
+    print(
+        f"{prefix}Notebooks: added={len(nb_results['added'])}, "
+        f"skipped={len(nb_results['skipped'])}"
+    )
+    for path in nb_results["added"]:
+        print(f"  + {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- Inserted Colab and Binder launch badges into the top of each chapter's markdown file and corresponding Jupyter notebook.
- Updated IDs in Jupyter notebooks to maintain sequential order after badge insertion.
- Created a script to automate the addition of badges to markdown and notebook files.
- Modified myst.yml to remove the commented-out Thebe configuration.